### PR TITLE
Fix: 修复国外用户访问，系统异常弹框问题

### DIFF
--- a/aurora-springboot/src/main/java/com/aurora/util/IpUtil.java
+++ b/aurora-springboot/src/main/java/com/aurora/util/IpUtil.java
@@ -90,10 +90,15 @@ public class IpUtil {
 
     public static String getIpProvince(String ipSource) {
         String[] strings = ipSource.split("\\|");
-        if (strings[1].endsWith("省")) {
-            return StringUtils.substringBefore(strings[1], "省");
+        try {
+            if (strings[1].endsWith("省")) {
+                return StringUtils.substringBefore(strings[1], "省");
+            }
+            return strings[1];
+        } catch (Exception e) {
+            log.warn("Warn: Invaild provice");
+            return "";
         }
-        return strings[1];
     }
 
     public static UserAgent getUserAgent(HttpServletRequest request) {


### PR DESCRIPTION
修复国外用户访问，登录系统首页和控制台，右上角弹框提示异常。
fix below issue:
```
java.lang.ArrayIndexOutOfBoundsException: 1
	at com.aurora.util.IpUtil.getIpProvince(IpUtil.java:93)
	at com.aurora.service.impl.AuroraInfoServiceImpl.report(AuroraInfoServiceImpl.java:82)
	at com.aurora.service.impl.AuroraInfoServiceImpl$$FastClassBySpringCGLIB$$50a233f3.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:687)
	at com.aurora.service.impl.AuroraInfoServiceImpl$$EnhancerBySpringCGLIB$$92652d7f.report(<generated>)
	at com.aurora.controller.AuroraInfoController.report(AuroraInfoController.java:39)
	at com.aurora.controller.AuroraInfoController$$FastClassBySpringCGLIB$$ae14dc1b.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
```